### PR TITLE
fix: Implement missing recursive `is_cachable()` for `Expr::Localize`

### DIFF
--- a/askama/src/i18n.rs
+++ b/askama/src/i18n.rs
@@ -62,7 +62,7 @@ impl Locale<'_> {
 
     pub fn translate<'a>(
         &self,
-        text_id: &str,
+        msg_id: &str,
         args: impl IntoIterator<Item = (&'a str, FluentValue<'a>)>,
     ) -> Option<String> {
         let args = HashMap::<&str, FluentValue<'_>>::from_iter(args);
@@ -70,7 +70,7 @@ impl Locale<'_> {
             true => None,
             false => Some(&args),
         };
-        self.loader.lookup_complete(&self.language, text_id, args)
+        self.loader.lookup_complete(&self.language, msg_id, args)
     }
 }
 

--- a/askama_derive/src/generator.rs
+++ b/askama_derive/src/generator.rs
@@ -1292,7 +1292,7 @@ impl<'a> Generator<'a> {
             Expr::Try(ref expr) => self.visit_try(buf, expr.as_ref())?,
             Expr::Tuple(ref exprs) => self.visit_tuple(buf, exprs)?,
             #[cfg(feature = "i18n")]
-            Expr::Localize(ref message, ref args) => self.visit_localize(buf, message, args)?,
+            Expr::Localize(ref msg_id, ref args) => self.visit_localize(buf, msg_id, args)?,
         })
     }
 
@@ -1300,7 +1300,7 @@ impl<'a> Generator<'a> {
     fn visit_localize(
         &mut self,
         buf: &mut Buffer,
-        message: &Expr<'_>,
+        msg_id: &Expr<'_>,
         args: &[(&str, Expr<'_>)],
     ) -> Result<DisplayWrap, CompileError> {
         let localizer =
@@ -1312,7 +1312,7 @@ impl<'a> Generator<'a> {
             "self.{}.translate(",
             normalize_identifier(localizer)
         ));
-        self.visit_expr(buf, message)?;
+        self.visit_expr(buf, msg_id)?;
         buf.writeln(", [")?;
         buf.indent();
         for (k, v) in args {
@@ -1321,7 +1321,7 @@ impl<'a> Generator<'a> {
             buf.writeln(")),")?;
         }
         buf.dedent()?;
-        // Safe to unwrap, as `message` is checked at compile time.
+        // Safe to unwrap, as `msg_id` is checked at compile time.
         buf.write("]).unwrap()");
 
         Ok(DisplayWrap::Unwrapped)

--- a/askama_derive/src/i18n.rs
+++ b/askama_derive/src/i18n.rs
@@ -286,7 +286,7 @@ pub(crate) fn load(input: TokenStream) -> Result<TokenStream, CompileError> {
     Ok(ts.into())
 }
 
-pub(crate) fn arguments_of(text_id: &str) -> Result<HashSet<&'static str>, CompileError> {
+pub(crate) fn arguments_of(msg_id: &str) -> Result<HashSet<&'static str>, CompileError> {
     let config = get_i18n_config()?;
     let entry = config.fallbacks[&config.fallback]
         .iter()
@@ -303,8 +303,8 @@ pub(crate) fn arguments_of(text_id: &str) -> Result<HashSet<&'static str>, Compi
             fluent_syntax::ast::Entry::Message(entry) => Some(entry),
             _ => None,
         })
-        .find(|entry| entry.id.name == text_id)
-        .ok_or_else(|| CompileError::from(format!("text_id {:?} not found", text_id)))?;
+        .find(|entry| entry.id.name == msg_id)
+        .ok_or_else(|| CompileError::from(format!("msg_id {:?} not found", msg_id)))?;
 
     let keys = entry
         .value

--- a/askama_derive/src/parser.rs
+++ b/askama_derive/src/parser.rs
@@ -135,6 +135,9 @@ impl Expr<'_> {
             }
             Expr::Group(arg) => arg.is_cachable(),
             Expr::Tuple(args) => args.iter().all(|arg| arg.is_cachable()),
+            Expr::Localize(text_id, args) => {
+                text_id.is_cachable() && args.iter().all(|(_, arg)| arg.is_cachable())
+            }
             // We have too little information to tell if the expression is pure:
             Expr::Call(_, _) => false,
             Expr::RustMacro(_, _) => false,

--- a/testing/tests/i18n.rs
+++ b/testing/tests/i18n.rs
@@ -22,7 +22,7 @@ struct UsesNoArgsI18n<'a> {
 }
 
 #[test]
-fn existing_language() {
+fn test_existing_language() {
     let template = UsesI18n {
         loc: Locale::new(langid!("es-MX"), &LOCALES),
         name: "Hilda",
@@ -36,7 +36,7 @@ fn existing_language() {
 }
 
 #[test]
-fn fallback_language() {
+fn test_fallback_language() {
     let template = UsesI18n {
         loc: Locale::new(langid!("nl-BE"), &LOCALES),
         name: "Hilda",
@@ -50,7 +50,7 @@ fn fallback_language() {
 }
 
 #[test]
-fn no_args() {
+fn test_no_args() {
     let template = UsesNoArgsI18n {
         loc: Locale::new(langid!("en-US"), &LOCALES),
     };


### PR DESCRIPTION
# [fix: Implement missing recursive is_cachable() for Expr::Localize](https://github.com/11Tuvork28/askama/pull/6/commits/b52aaf30f180170f884b541e20597d5d606122c9)

Check recursively if `Expr::Localize` is cacheable.

Rationale: 
Lookup is static and reproducible and thus cachable for each set of `text_id` and arguments.

Therefore, `localize()` exprs are cachable whenever their input is cachable.

# [fix(style): Name localization message identifier as in Fluent Project](https://github.com/11Tuvork28/askama/pull/6/commits/9909c36cbe106e6b5feae29838d49926a0e077d0)

Quote from https://projectfluent.org/fluent/guide/hello.html

```ftl
hello = Hello, world!
```

Each **message** has an **identifier** that allows the developer to bind it to the place in the software where it will be used. The above message is called `hello`.

# [fix(style): Normalize test names, prefix all with test_](https://github.com/11Tuvork28/askama/pull/6/commits/6cda9f57b8c522d083b14af4b4e5fd1bc4d20842)

Bring names of `i18n` tests in line with all other tests, by prefixing `test_`:

![image](https://user-images.githubusercontent.com/22329650/195167295-123ca2f7-bbd7-4fe5-8462-396e771e61ea.png)
